### PR TITLE
DB設計のREADMEの記載

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|title|string|null: false|
+|name|string|null: false|
 
 ### Association(group)
 - has_many :users, through: :groups_users
@@ -41,7 +41,7 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|body|string|null: false|
+|body|string||
 |image|string||
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 ### Association(group)
 - has_many :users, through: :groups_users
 - has_many :messages
+- has_many :groups_users
 
 ## userテーブル
 
@@ -23,6 +24,7 @@
 ### Association(user)
 - has_many :groups, through: :groups_users
 - has_many :messages
+- has_many :groups_users
 
 ## groups_usersテーブル
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,49 @@
 # README
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+# DB設計
 
-Things you may want to cover:
+## groupテーブル
 
-* Ruby version
+|Column|Type|Options|
+|------|----|-------|
+|title|string|null: false|
 
-* System dependencies
+### Association(group)
+- has_many :users, through: :groups_users
+- has_many :messages
 
-* Configuration
+## userテーブル
 
-* Database creation
+|Column|Type|Options|
+|------|----|-------|
+|name|string|index|
+|email|string|null: false|
+|password|string|null: false|
 
-* Database initialization
+### Association(user)
+- has_many :groups, through: :groups_users
+- has_many :messages
 
-* How to run the test suite
+## groups_usersテーブル
 
-* Services (job queues, cache servers, search engines, etc.)
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 
-* Deployment instructions
+### Association(groups_users)
+- belongs_to :group
+- belongs_to :user
 
-* ...
+## messageテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|body|string|null: false|
+|image|string||
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association(message)
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|name|string|index|
+|name|string|null: false, index: true|
 |email|string|null: false|
 |password|string|null: false|
 


### PR DESCRIPTION
# What
DB設計のためのREADMEの記載。
4つのテーブルを作成。それぞれのカラム名、カラムの型、オプションについて記載。
アソシエーションの関係を記載。

# Why
chat-spaceをユーザが利用するにあたって、各種データの保存ができるようになるから。
DB設計の前段階として、内容に相違がないか確認のためにREADMEの記載があることにより、戻り作業が発生せず、今後の開発が円滑に進むから。